### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/openspending/datatoload.png?label=ready&title=Ready)](https://waffle.io/openspending/datatoload)
 # Hello there!
 
 **What is this?** This is the **community tracker** for work to **load data** into [OpenSpending][]


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/openspending/datatoload

This was requested by a real person (user rgrp) on waffle.io, we're not trying to spam you.
